### PR TITLE
Fix for ruby 3.0.0

### DIFF
--- a/lib/garden_variety/controller.rb
+++ b/lib/garden_variety/controller.rb
@@ -330,7 +330,7 @@ module GardenVariety
         :"flash.#{status}",
         :"flash.#{status}_html",
       ]
-      helpers.translate(keys.shift, { default: keys }.merge!(flash_options))
+      helpers.translate(keys.shift, **{ default: keys }.merge!(flash_options))
     end
   end
 end


### PR DESCRIPTION
Doesn't seem like the *best* fix, but gets the job done. Backward compatible with ruby 2.7.2